### PR TITLE
Fixing #6145, Opening file with Ctrl-click resulting in network error

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/openItem.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/openItem.ts
@@ -26,7 +26,9 @@ export const runtime = (): CommandRuntime => {
 					// shell.openPath seems to work with file:// urls on Windows,
 					// but doesn't on macOS, so we need to convert it to a path
 					// before passing it to openPath.
-					const decodedPath = fileUriToPath(urlDecode(link), shim.platformName());
+					let decodedPath = fileUriToPath(urlDecode(link), shim.platformName());
+					if(decodedPath.indexOf('\\') === 0)
+						decodedPath = decodedPath.substring(2);
 					void require('electron').shell.openPath(decodedPath);
 				} else {
 					void require('electron').shell.openExternal(link);


### PR DESCRIPTION
## "Desktop" Fixing issue #6145 Opening a file with Ctrl-click in rich text editor resulting in a network error.


### Overview
In single text editor mode, when opening a file attachment using "Ctrl-click" a network error occurs.

![image](https://user-images.githubusercontent.com/75777457/154851141-6871ed04-4a5d-4199-9e47-7f93598333de.png)

### Solution
For windows, while modifying the file path, the starting two backslashes are not removed. These two backslashes need to be removed manually. On other OS, starting backslashes do not appear after modification. So it works fine for Mac and Linux